### PR TITLE
Add dark mode support for colors

### DIFF
--- a/app/javascript/pages/Habits/Edit.jsx
+++ b/app/javascript/pages/Habits/Edit.jsx
@@ -13,28 +13,28 @@ export default function Edit({ habit, errors }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center space-x-4 mb-4">
             <Link
               href={`/habits/${habit.id}`}
-              className="text-indigo-600 hover:text-indigo-500"
+              className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300"
             >
               ← Back to Habit
             </Link>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">Edit Habit</h1>
-          <p className="text-lg text-gray-600 mt-2">Update your habit details</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Edit Habit</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">Update your habit details</p>
         </div>
 
         {/* Form */}
-        <div className="bg-white shadow rounded-lg p-6">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
           <form onSubmit={handleSubmit}>
             {/* Title Field */}
             <div className="mb-6">
-              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Habit Title *
               </label>
               <input
@@ -43,19 +43,19 @@ export default function Edit({ habit, errors }) {
                 name="title"
                 value={data.title}
                 onChange={(e) => setData('title', e.target.value)}
-                className={`block w-full px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${
-                  errors?.title ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''
+                className={`block w-full px-3 py-2 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 dark:focus:border-indigo-400 focus:ring-indigo-500 dark:focus:ring-indigo-400 sm:text-sm ${
+                  errors?.title ? 'border-red-300 dark:border-red-600 focus:border-red-500 dark:focus:border-red-400 focus:ring-red-500 dark:focus:ring-red-400' : ''
                 }`}
                 placeholder="e.g., Drink 8 glasses of water"
               />
               {errors?.title && (
-                <p className="mt-2 text-sm text-red-600">{errors.title[0]}</p>
+                <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.title[0]}</p>
               )}
             </div>
 
             {/* Description Field */}
             <div className="mb-6">
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Description (Optional)
               </label>
               <textarea
@@ -64,13 +64,13 @@ export default function Edit({ habit, errors }) {
                 rows={4}
                 value={data.description}
                 onChange={(e) => setData('description', e.target.value)}
-                className={`block w-full px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${
-                  errors?.description ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''
+                className={`block w-full px-3 py-2 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 dark:focus:border-indigo-400 focus:ring-indigo-500 dark:focus:ring-indigo-400 sm:text-sm ${
+                  errors?.description ? 'border-red-300 dark:border-red-600 focus:border-red-500 dark:focus:border-red-400 focus:ring-red-500 dark:focus:ring-red-400' : ''
                 }`}
                 placeholder="Describe your habit, why it's important to you, or any additional details..."
               />
               {errors?.description && (
-                <p className="mt-2 text-sm text-red-600">{errors.description[0]}</p>
+                <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.description[0]}</p>
               )}
             </div>
 
@@ -78,14 +78,14 @@ export default function Edit({ habit, errors }) {
             <div className="flex justify-end space-x-4">
               <Link
                 href={`/habits/${habit.id}`}
-                className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
               >
                 Cancel
               </Link>
               <button
                 type="submit"
                 disabled={processing}
-                className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 dark:bg-indigo-700 hover:bg-indigo-700 dark:hover:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 disabled:opacity-50"
               >
                 {processing ? 'Updating...' : 'Update Habit'}
               </button>
@@ -94,8 +94,8 @@ export default function Edit({ habit, errors }) {
         </div>
 
         {/* Creation Info */}
-        <div className="mt-6 bg-gray-50 border border-gray-200 rounded-md p-4">
-          <div className="text-sm text-gray-600">
+        <div className="mt-6 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md p-4">
+          <div className="text-sm text-gray-600 dark:text-gray-300">
             <p>Created on {new Date(habit.created_at).toLocaleDateString()}</p>
             {habit.updated_at !== habit.created_at && (
               <p>Last updated on {new Date(habit.updated_at).toLocaleDateString()}</p>

--- a/app/javascript/pages/Habits/Index.jsx
+++ b/app/javascript/pages/Habits/Index.jsx
@@ -35,16 +35,16 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-4">HabtTrkr!</h1>
-          <p className="text-lg text-gray-600 mb-6">Track your daily habits and build consistency</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">HabtTrkr!</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">Track your daily habits and build consistency</p>
 
           <Link
             href="/habits/new"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 dark:bg-indigo-700 hover:bg-indigo-700 dark:hover:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
           >
             + Create New Habit
           </Link>
@@ -52,12 +52,12 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
 
         {/* 14-Day Overview */}
         {fourteen_day_overview && (
-          <div className="mb-8 bg-white shadow rounded-lg p-6">
+          <div className="mb-8 bg-white dark:bg-gray-800 shadow rounded-lg p-6">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-semibold text-gray-900">14-Day Overview</h2>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">14-Day Overview</h2>
               <div className="text-right">
-                <div className="text-sm text-gray-600">Current Streak</div>
-                <div className="text-2xl font-bold text-indigo-600">
+                <div className="text-sm text-gray-600 dark:text-gray-300">Current Streak</div>
+                <div className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
                   {fourteen_day_overview.current_streak} {fourteen_day_overview.current_streak === 1 ? 'day' : 'days'}
                 </div>
               </div>
@@ -66,22 +66,22 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
                         <div className="flex justify-between gap-1">
               {fourteen_day_overview.dates.map((dayData, index) => (
                 <div key={dayData.date} className="text-center flex-1">
-                  <div className="text-xs text-gray-500 mb-1">{dayData.day_name}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{dayData.day_name}</div>
                   <div
                     className={`
                       w-8 h-8 mx-auto rounded-md flex items-center justify-center text-xs font-medium border
                       ${dayData.habits_completed > 0
-                        ? 'bg-green-100 border-green-300 text-green-800'
-                        : 'bg-gray-50 border-gray-200 text-gray-400'
+                        ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600 text-green-800 dark:text-green-300'
+                        : 'bg-gray-50 dark:bg-gray-700 border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500'
                       }
-                      ${dayData.is_today ? 'ring-2 ring-indigo-500' : ''}
+                      ${dayData.is_today ? 'ring-2 ring-indigo-500 dark:ring-indigo-400' : ''}
                     `}
                     title={`${dayData.habits_completed} habits completed`}
                   >
                     {dayData.day_number}
                   </div>
                   {dayData.habits_completed > 0 && (
-                    <div className="text-xs text-green-600 mt-1">
+                    <div className="text-xs text-green-600 dark:text-green-400 mt-1">
                       {dayData.habits_completed} habits completed
                     </div>
                   )}
@@ -93,43 +93,43 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
 
         {/* Flash Messages */}
         {flash?.notice && (
-          <div className="mb-4 bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
+          <div className="mb-4 bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-300 px-4 py-3 rounded">
             {flash.notice}
           </div>
         )}
 
         {flash?.alert && (
-          <div className="mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          <div className="mb-4 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 px-4 py-3 rounded">
             {flash.alert}
           </div>
         )}
 
         {/* Habits List */}
-        <div className="bg-white shadow rounded-lg">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
           {habits && habits.length > 0 ? (
-            <div className="divide-y divide-gray-200">
+            <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {habits.map((habit) => (
-                <div key={habit.id} className="p-6 hover:bg-gray-50 habit-item">
+                <div key={habit.id} className="p-6 hover:bg-gray-50 dark:hover:bg-gray-700 habit-item">
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center mb-2">
-                        <h3 className="text-lg font-medium text-gray-900 mr-3">
+                        <h3 className="text-lg font-medium text-gray-900 dark:text-white mr-3">
                           {habit.title}
                         </h3>
                         {habit.completed_today && (
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300">
                             ✓ Completed today
                           </span>
                         )}
                       </div>
                       {habit.description && (
-                        <p className="text-gray-600 mb-4">{habit.description}</p>
+                        <p className="text-gray-600 dark:text-gray-300 mb-4">{habit.description}</p>
                       )}
 
                       {/* Simplified Streak Information */}
-                      <div className="mb-4 p-4 bg-gray-50 rounded-lg">
-                        <h4 className="font-medium text-gray-900 mb-2">Statistics</h4>
-                        <div className="space-y-1 text-sm text-gray-600">
+                      <div className="mb-4 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                        <h4 className="font-medium text-gray-900 dark:text-white mb-2">Statistics</h4>
+                        <div className="space-y-1 text-sm text-gray-600 dark:text-gray-300">
                           <div>Current Streak: {formatStreakText(habit.current_streak || 0)}</div>
                           <div>Longest Streak: {formatStreakText(habit.longest_streak || 0)}</div>
                           <div>Total: {formatCompletionsText(habit.total_completions || 0)}</div>
@@ -141,14 +141,14 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
                       {habit.completed_today ? (
                         <button
                           onClick={() => handleUncomplete(habit.id)}
-                          className="inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                          className="inline-flex items-center px-3 py-1 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
                         >
                           Mark Incomplete
                         </button>
                       ) : (
                         <button
                           onClick={() => handleComplete(habit.id)}
-                          className="inline-flex items-center px-3 py-1 border border-green-300 text-sm font-medium rounded-md text-green-700 bg-green-50 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                          className="inline-flex items-center px-3 py-1 border border-green-300 dark:border-green-600 text-sm font-medium rounded-md text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-900 hover:bg-green-100 dark:hover:bg-green-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 dark:focus:ring-green-400"
                         >
                           Mark Complete
                         </button>
@@ -158,19 +158,19 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
                       <div className="flex space-x-2">
                         <Link
                           href={`/habits/${habit.id}`}
-                          className="inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                          className="inline-flex items-center px-3 py-1 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
                         >
                           View
                         </Link>
                         <Link
                           href={`/habits/${habit.id}/edit`}
-                          className="inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                          className="inline-flex items-center px-3 py-1 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
                         >
                           Edit
                         </Link>
                         <button
                           onClick={() => handleDelete(habit.id, habit.title)}
-                          className="inline-flex items-center px-3 py-1 border border-red-300 text-sm font-medium rounded-md text-red-700 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                          className="inline-flex items-center px-3 py-1 border border-red-300 dark:border-red-600 text-sm font-medium rounded-md text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900 hover:bg-red-100 dark:hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-red-400"
                         >
                           Delete
                         </button>
@@ -182,16 +182,16 @@ export default function Index({ habits, flash, fourteen_day_overview }) {
             </div>
           ) : (
             <div className="p-12 text-center">
-              <div className="mx-auto h-12 w-12 text-gray-400 mb-4">
+              <div className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500 mb-4">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                 </svg>
               </div>
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No habits yet</h3>
-              <p className="text-gray-600 mb-4">Get started by creating your first habit to track.</p>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">No habits yet</h3>
+              <p className="text-gray-600 dark:text-gray-300 mb-4">Get started by creating your first habit to track.</p>
               <Link
                 href="/habits/new"
-                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 dark:bg-indigo-700 hover:bg-indigo-700 dark:hover:bg-indigo-800"
               >
                 Create Your First Habit
               </Link>

--- a/app/javascript/pages/Habits/New.jsx
+++ b/app/javascript/pages/Habits/New.jsx
@@ -13,28 +13,28 @@ export default function New({ habit, errors }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center space-x-4 mb-4">
             <Link
               href="/habits"
-              className="text-indigo-600 hover:text-indigo-500"
+              className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300"
             >
               ← Back to Habits
             </Link>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">Create New Habit</h1>
-          <p className="text-lg text-gray-600 mt-2">Start tracking a new habit today</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Create New Habit</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300 mt-2">Start tracking a new habit today</p>
         </div>
 
         {/* Form */}
-        <div className="bg-white shadow rounded-lg p-6">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
           <form onSubmit={handleSubmit}>
             {/* Title Field */}
             <div className="mb-6">
-              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Habit Title *
               </label>
               <input
@@ -43,21 +43,21 @@ export default function New({ habit, errors }) {
                 name="title"
                 value={data.title}
                 onChange={(e) => setData('title', e.target.value)}
-                className={`block w-full px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${
-                  errors?.title ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''
+                className={`block w-full px-3 py-2 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 dark:focus:border-indigo-400 focus:ring-indigo-500 dark:focus:ring-indigo-400 sm:text-sm ${
+                  errors?.title ? 'border-red-300 dark:border-red-600 focus:border-red-500 dark:focus:border-red-400 focus:ring-red-500 dark:focus:ring-red-400' : ''
                 }`}
                 placeholder="e.g., Drink 8 glasses of water"
                 autoFocus
                 required
               />
               {errors?.title && (
-                <p className="mt-2 text-sm text-red-600">{errors.title[0]}</p>
+                <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.title[0]}</p>
               )}
             </div>
 
             {/* Description Field */}
             <div className="mb-6">
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Description (Optional)
               </label>
               <textarea
@@ -66,13 +66,13 @@ export default function New({ habit, errors }) {
                 rows={4}
                 value={data.description}
                 onChange={(e) => setData('description', e.target.value)}
-                className={`block w-full px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm ${
-                  errors?.description ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : ''
+                className={`block w-full px-3 py-2 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 dark:focus:border-indigo-400 focus:ring-indigo-500 dark:focus:ring-indigo-400 sm:text-sm ${
+                  errors?.description ? 'border-red-300 dark:border-red-600 focus:border-red-500 dark:focus:border-red-400 focus:ring-red-500 dark:focus:ring-red-400' : ''
                 }`}
                 placeholder="Describe your habit, why it's important to you, or any additional details..."
               />
               {errors?.description && (
-                <p className="mt-2 text-sm text-red-600">{errors.description[0]}</p>
+                <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.description[0]}</p>
               )}
             </div>
 
@@ -80,14 +80,14 @@ export default function New({ habit, errors }) {
             <div className="flex justify-end space-x-4">
               <Link
                 href="/habits"
-                className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
               >
                 Cancel
               </Link>
               <button
                 type="submit"
                 disabled={processing}
-                className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 dark:bg-indigo-700 hover:bg-indigo-700 dark:hover:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 disabled:opacity-50"
               >
                 {processing ? 'Creating...' : 'Create Habit'}
               </button>
@@ -96,16 +96,16 @@ export default function New({ habit, errors }) {
         </div>
 
         {/* Help Text */}
-        <div className="mt-6 bg-blue-50 border border-blue-200 rounded-md p-4">
+        <div className="mt-6 bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded-md p-4">
           <div className="flex">
             <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="h-5 w-5 text-blue-400 dark:text-blue-300" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
               </svg>
             </div>
             <div className="ml-3">
-              <h3 className="text-sm font-medium text-blue-800">Tips for creating effective habits</h3>
-              <div className="mt-2 text-sm text-blue-700">
+              <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200">Tips for creating effective habits</h3>
+              <div className="mt-2 text-sm text-blue-700 dark:text-blue-300">
                 <ul className="list-disc pl-5 space-y-1">
                   <li>Make it specific and measurable</li>
                   <li>Start small and build up gradually</li>

--- a/app/javascript/pages/Habits/Show.jsx
+++ b/app/javascript/pages/Habits/Show.jsx
@@ -9,14 +9,14 @@ export default function Show({ habit, flash }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center space-x-4 mb-4">
             <Link
               href="/habits"
-              className="text-indigo-600 hover:text-indigo-500"
+              className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300"
             >
               ← Back to Habits
             </Link>
@@ -25,31 +25,31 @@ export default function Show({ habit, flash }) {
 
         {/* Flash Messages */}
         {flash?.notice && (
-          <div className="mb-4 bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
+          <div className="mb-4 bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-300 px-4 py-3 rounded">
             {flash.notice}
           </div>
         )}
 
         {/* Habit Details */}
-        <div className="bg-white shadow rounded-lg p-6">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
           {/* Title and Actions */}
           <div className="flex justify-between items-start mb-6">
             <div className="flex-1">
-              <h1 className="text-3xl font-bold text-gray-900 mb-2">{habit.title}</h1>
-              <p className="text-sm text-gray-500">
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">{habit.title}</h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
                 Created on {new Date(habit.created_at).toLocaleDateString()}
               </p>
             </div>
             <div className="flex space-x-2">
               <Link
                 href={`/habits/${habit.id}/edit`}
-                className="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                className="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
               >
                 Edit
               </Link>
               <button
                 onClick={handleDelete}
-                className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 dark:bg-red-700 hover:bg-red-700 dark:hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-red-400"
               >
                 Delete
               </button>
@@ -59,21 +59,21 @@ export default function Show({ habit, flash }) {
           {/* Description */}
           {habit.description && (
             <div className="mb-6">
-              <h3 className="text-lg font-medium text-gray-900 mb-2">Description</h3>
-              <p className="text-gray-600 whitespace-pre-wrap">{habit.description}</p>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">Description</h3>
+              <p className="text-gray-600 dark:text-gray-300 whitespace-pre-wrap">{habit.description}</p>
             </div>
           )}
 
           {/* Placeholder for future tracking features */}
-          <div className="border-t border-gray-200 pt-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Tracking</h3>
-            <div className="bg-gray-50 rounded-md p-4 text-center">
-              <div className="text-gray-400 mb-2">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Tracking</h3>
+            <div className="bg-gray-50 dark:bg-gray-700 rounded-md p-4 text-center">
+              <div className="text-gray-400 dark:text-gray-500 mb-2">
                 <svg className="mx-auto h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                 </svg>
               </div>
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
                 Habit tracking features coming soon! You'll be able to mark completion, view streaks, and see your progress here.
               </p>
             </div>

--- a/app/javascript/pages/Welcome.jsx
+++ b/app/javascript/pages/Welcome.jsx
@@ -2,15 +2,15 @@ import React from 'react'
 
 export default function Welcome() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div className="max-w-md mx-auto text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
           Welcome to HabtTrkr
         </h1>
-        <p className="text-lg text-gray-600 mb-8">
+        <p className="text-lg text-gray-600 dark:text-gray-300 mb-8">
           Your app is now powered by Inertia.js and React!
         </p>
-        <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
+        <div className="bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-300 px-4 py-3 rounded">
           ✅ Inertia.js + React is successfully configured
         </div>
       </div>


### PR DESCRIPTION
Dark mode support was implemented by systematically adding `dark:` variants to existing Tailwind CSS color classes across the application's React components.

Changes were applied to:
*   `app/javascript/pages/Welcome.jsx`
*   `app/javascript/pages/Habits/Index.jsx`
*   `app/javascript/pages/Habits/Edit.jsx`
*   `app/javascript/pages/Habits/New.jsx`
*   `app/javascript/pages/Habits/Show.jsx`

Specific color adjustments include:
*   **Backgrounds:** Classes like `bg-gray-50` were updated to `dark:bg-gray-900`, and `bg-white` to `dark:bg-gray-800`.
*   **Text:** `text-gray-900` became `dark:text-white`, and `text-gray-600` became `dark:text-gray-300`.
*   **Borders:** `border-gray-300` was updated to `dark:border-gray-600`.
*   **Interactive States:** Hover, focus, and ring colors (e.g., `focus:ring-indigo-500`) received corresponding dark variants (e.g., `dark:focus:ring-indigo-400`).
*   **Semantic Colors:** Green, red, and blue alert/status colors, as well as indigo accent colors, were also given dark counterparts (e.g., `bg-green-100` to `dark:bg-green-900`).

The application now automatically adapts its color scheme based on the user's system dark mode preference, without requiring an in-app toggle.